### PR TITLE
Add man pages and perform some repo housekeeping

### DIFF
--- a/51-ec2-hvm-devices.rules
+++ b/51-ec2-hvm-devices.rules
@@ -1,4 +1,4 @@
-# Copyright 2006 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the MIT License. See the LICENSE accompanying this file
 # for the specific language governing permissions and limitations under

--- a/52-ec2-vcpu.rules
+++ b/52-ec2-vcpu.rules
@@ -1,4 +1,4 @@
-# Copyright 2014 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the MIT License. See the LICENSE accompanying this file
 # for the specific language governing permissions and limitations under

--- a/60-cdrom_id.rules
+++ b/60-cdrom_id.rules
@@ -1,4 +1,4 @@
-# Copyright 2016 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the MIT License. See the LICENSE accompanying this file
 # for the specific language governing permissions and limitations under

--- a/70-ec2-nvme-devices.rules
+++ b/70-ec2-nvme-devices.rules
@@ -1,4 +1,4 @@
-# Copyright 2006 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the MIT License. See the LICENSE accompanying this file
 # for the specific language governing permissions and limitations under

--- a/README.md
+++ b/README.md
@@ -9,5 +9,7 @@ It includes:
 
 ## License
 
-This package is licensed under the MIT License.
+The utilities in this package are published under the MIT License.  The
+documentation in the doc subdirectory is licensed under the Creative Commons
+Attribution-ShareAlike 4.0 International License.
 

--- a/doc/ebsnvme-id.8
+++ b/doc/ebsnvme-id.8
@@ -1,0 +1,41 @@
+.\" Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+.\"
+.\" This work is licensed under the Creative Commons
+ \" Attribution-ShareAlike 4.0 International License. To view a copy
+ \" of this license, visit
+ \" http://creativecommons.org/licenses/by-sa/4.0/.
+ \" SPDX-License-Identifier: CC-BY-SA-4.0
+.TH EBSNVME-ID 8 "May  4 2020"
+.SH NAME
+ebsnvme-id \- Reads and prints EBS information from NVMe devices
+.SH SYNOPSIS
+.B ebsnvme-id
+.RI [ options ] " DEVICE"
+.br
+.SH DESCRIPTION
+.B ebsnvme-id
+uses the NVME Management Interface to read various metadata about
+NVME-attached EBS storage volumes.  It can be used to retrive the EBS
+Volume ID or EC2 API device mapping value given the local block device
+name.
+
+.SH OPTIONS
+.TP
+.B \-v, \-\-volume
+Return volume-id
+.TP
+.B \-b, \-\-block-dev
+Return block device mapping
+.TP
+.B \-u, \-\-udev
+Output data in format suitable for udev rules                                                                            
+.TP
+.B \-h, \-\-help
+Show summary of options.
+.SH SEE ALSO
+.BR nvme (1),
+.BR ec2-metadata (1).
+.PP
+The storage chapter of the Amazon EC2 User Guide
+.br
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Storage.html

--- a/doc/ec2-metadata.8
+++ b/doc/ec2-metadata.8
@@ -1,0 +1,125 @@
+.\" Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+.\"
+.\" This work is licensed under the Creative Commons
+ \" Attribution-ShareAlike 4.0 International License. To view a copy
+ \" of this license, visit
+ \" http://creativecommons.org/licenses/by-sa/4.0/.
+ \" SPDX-License-Identifier: CC-BY-SA-4.0
+.\"
+.\" Much of the text in the DESCRIPTION section is taken from
+.\" https://github.com/awsdocs/amazon-ec2-user-guide/blob/master/doc_source/ec2-instance-metadata.md
+.\"
+.TH EC2-METADATA 8 "May  4 2020"
+.SH NAME
+ec2-metadata \- Retrieve instance metadata from within a running EC2 instance
+.SH SYNOPSIS
+.B ec2-metadata
+.RI [ options ]
+.br
+.SH DESCRIPTION
+The
+.B ec2-metadata
+program is a utility to retrieve EC2 instance metadata from within a
+running EC2 instance.
+
+Instance metadata is data about your instance that you can use to
+configure or manage the running instance. Instance metadata is divided
+into categories, for example, host name, events, and security groups.
+
+You can also use instance metadata to access user data that you
+specified when launching your instance. For example, you can specify
+parameters for configuring your instance, or include a simple
+script. You can build generic AMIs and use user data to modify the
+configuration files supplied at launch time. For example, if you run
+web servers for various small businesses, they can all use the same
+generic AMI and retrieve their content from the Amazon S3 bucket that
+you specify in the user data at launch. To add a new customer at any
+time, create a bucket for the customer, add their content, and launch
+your AMI with the unique bucket name provided to your code in the user
+data. If you launch more than one instance at the same time, the user
+data is available to all instances in that reservation. Each instance
+that is part of the same reservation has a unique ami-launch-index
+number, allowing you to write code that controls what to do. For
+example, the first host might elect itself as an initial master node
+in a cluster.
+
+.PP
+.SH OPTIONS
+.B ec2-metadata
+will print all known metadata fields by default.  The following
+options can be used to restrict the output to the selected fields.
+
+.TP
+.B \-\-all                     Show all metadata information for this host (also default).
+.TP
+.B \-a/\-\-ami-id               The AMI ID used to launch this instance
+.TP
+.B \-l/\-\-ami-launch-index
+The index of this instance in the reservation (per AMI).
+.TP
+.B \-m/\-\-ami-manifest-path
+The manifest path of the AMI with which the instance was launched.
+.TP
+.B \-n/\-\-ancestor-ami-ids
+The AMI IDs of any instances that were rebundled to create this AMI.
+.TP
+.B \-b/\-\-block-device-mapping
+Defines native device names to use when exposing virtual devices.
+.TP
+.B \-i/\-\-instance-id
+The ID of this instance
+.TP
+.B \-t/\-\-instance-type
+The type of instance to launch. For more information, see Instance Types.
+.TP
+.B \-h/\-\-local-hostname
+The local hostname of the instance.
+.TP
+.B \-o/\-\-local-ipv4
+Public IP address if launched with direct addressing; private IP address if launched with public addressing.
+.TP
+.B \-k/\-\-kernel-id
+The ID of the kernel launched with this instance, if applicable.
+.TP
+.B \-z/\-\-availability-zone
+The availability zone in which the instance launched. Same as placement
+.TP
+.B \-c/\-\-product-codes
+Product codes associated with this instance.
+.TP
+.B \-p/\-\-public-hostname
+The public hostname of the instance.
+.TP
+.B \-v/\-\-public-ipv4
+NATted public IP Address
+.TP
+.B \-u/\-\-public-keys
+Public keys. Only available if supplied at instance launch time
+.TP
+.B \-r/\-\-ramdisk-id
+The ID of the RAM disk launched with this instance, if applicable.
+.TP
+.B \-e/\-\-reservation-id
+ID of the reservation.
+.TP
+.B \-s/\-\-security-groups
+Names of the security groups the instance is launched in. Only available if supplied at instance launch time
+.TP
+.B \-d/\-\-user-data
+User-supplied data.Only available if supplied at instance launch time.
+.TP
+.B \-h, \-\-help
+Show summary of options.
+.SH SEE ALSO
+.br
+.IP " 1." 4
+Instance metadata and user data
+.RS 4
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+.RE
+.IP " 2." 4
+EC2 Instance Metadata Query Tool
+.RS 4
+https://aws.amazon.com/code/ec2-instance-metadata-query-tool/
+.RE
+

--- a/ec2-metadata
+++ b/ec2-metadata
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2006 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the MIT License. See the LICENSE accompanying this file
 # for the specific language governing permissions and limitations under

--- a/ec2-metadata
+++ b/ec2-metadata
@@ -14,7 +14,7 @@ e.g. to retrieve instance id: ec2-metadata -i
 		 to retrieve ami id: ec2-metadata -a
 		 to get help: ec2-metadata --help
 For more information on Amazon EC2 instance meta-data, refer to the documentation at
-http://docs.amazonwebservices.com/AWSEC2/2008-05-05/DeveloperGuide/AESDG-chapter-instancedata.html
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 
 Usage: ec2-metadata <option>
 Options:

--- a/ec2udev-vbd
+++ b/ec2udev-vbd
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the MIT License. See the LICENSE accompanying this file
 # for the specific language governing permissions and limitations under

--- a/ec2udev-vcpu
+++ b/ec2udev-vcpu
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the MIT License. See the LICENSE accompanying this file
 # for the specific language governing permissions and limitations under


### PR DESCRIPTION
This PR adds missing documentation for the `ec2-metadata` and `ebsnvme-id` commands and performs other minor repository maintenance.

There is no change to the functionality of any of the software.

Per AWS standards, the documentation is published under the CC-BY-SA-4.0 license.