### PR TITLE
Add udev rule to increase read_ahead_kb when an NFS share is mounted

### DIFF
--- a/53-ec2-read-ahead-kb.rules
+++ b/53-ec2-read-ahead-kb.rules
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+
+
+# increase read_ahead_kb when a nfs/efs export is mounted to improve throughput 
+SUBSYSTEM=="bdi", ACTION=="add", PROGRAM="/bin/awk -v bdi=$kernel 'BEGIN{ret=1} {if ($4 == bdi) {ret=0}} END{exit ret}' /proc/fs/nfsfs/volumes", ATTR{read_ahead_kb}="15360"

--- a/amazon-ec2-utils.spec
+++ b/amazon-ec2-utils.spec
@@ -1,7 +1,7 @@
 Name:      amazon-ec2-utils
 Summary:   A set of tools for running in EC2
 Version:   1.3
-Release:   2%{?dist}
+Release:   3%{?dist}
 License:   MIT
 Group:     System Tools
 
@@ -15,6 +15,7 @@ Source22:  70-ec2-nvme-devices.rules
 Source23:  ec2nvme-nsid
 Source24:  ebsnvme-id
 Source25:  51-ec2-xen-vbd-devices.rules
+Source26:  53-ec2-read-ahead-kb.rules
 
 URL:       https://github.com/aws/amazon-ec2-utils
 BuildArch: noarch
@@ -52,6 +53,7 @@ install -m644 %{SOURCE2} $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d/
 install -m645 %{SOURCE3} $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d/
 install -m644 %{SOURCE16} $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d/
 install -m644 %{SOURCE25} $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d/
+install -m644 %{SOURCE26} $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d/
 
 #udev rules for nvme block devices and supporting scripts
 install -m644 %{SOURCE22} $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d/
@@ -84,10 +86,14 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/udev/rules.d/51-ec2-hvm-devices.rules
 %{_sysconfdir}/udev/rules.d/51-ec2-xen-vbd-devices.rules
 %{_sysconfdir}/udev/rules.d/52-ec2-vcpu.rules
+%{_sysconfdir}/udev/rules.d/53-ec2-read-ahead-kb.rules
 %{_sysconfdir}/udev/rules.d/60-cdrom_id.rules
 %{_sysconfdir}/udev/rules.d/70-ec2-nvme-devices.rules
 
 %changelog
+* Tue Apr 20 2021 Hailey Mothershead <hailmo@amazon.com 1.3-3
+- Add udev rule to increase read_ahead_kb when an NFS share is mounted
+
 * Thu Oct 29 2020 Frederick Lefebvre <fredlef@amazon.com> 1.3-2
 - Add testing of python syntax to spec file
 

--- a/amazon-ec2-utils.spec
+++ b/amazon-ec2-utils.spec
@@ -91,7 +91,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/udev/rules.d/70-ec2-nvme-devices.rules
 
 %changelog
-* Tue Apr 20 2021 Hailey Mothershead <hailmo@amazon.com 1.3-3
+* Tue Apr 20 2021 Hailey Mothershead <hailmo@amazon.com> 1.3-3
 - Add udev rule to increase read_ahead_kb when an NFS share is mounted
 
 * Thu Oct 29 2020 Frederick Lefebvre <fredlef@amazon.com> 1.3-2


### PR DESCRIPTION
*Description of changes:*
Adding a udev rule to increase the read_ahead_kb value to an old kernel default value when an nfs share is mounted to remedy latency seen with efs. 

Before Change:

```
$ uname -r;sudo mount -t nfs4 -o nfsvers=4.1,hard,timeo=600,retrans=2,noresvport fs-b36e9c87.efs.eu-west-1.amazonaws.com:/ efs;sudo ./nfs-readahead show /home/ec2-user/efs/; time rsync  efs/test .
5.4.0-1.132.64.amzn2.x86_64
/home/ec2-user/efs 0:40 /sys/class/bdi/0:40/read_ahead_kb = 128

real    0m14.428s
user    0m3.842s
sys    0m1.099s
```
After Change:

```
$ uname -r;sudo mount -t nfs4 -o nfsvers=4.1,hard,timeo=600,retrans=2,noresvport fs-b36e9c87.efs.eu-west-1.amazonaws.com:/ efs;sudo ./nfs-readahead show /home/ec2-user/efs/; time rsync  efs/test .
5.4.0-1.132.64.amzn2.x86_64
/home/ec2-user/efs 0:40 /sys/class/bdi/0:40/read_ahead_kb = 15360

real    0m3.579s
user    0m3.848s
sys    0m0.929s
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
