### PR TITLE
Disable timeout on EBS volumes

### DIFF
--- a/70-ec2-nvme-devices.rules
+++ b/70-ec2-nvme-devices.rules
@@ -14,5 +14,9 @@ KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{serial}=="?
 # ebs nvme devices
 KERNEL=="nvme[0-9]*n[0-9]*",        ENV{DEVTYPE}=="disk",      ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/sbin/ebsnvme-id -u /dev/%k", SYMLINK+="%c"
 KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/sbin/ebsnvme-id -u /dev/%k", SYMLINK+="%c%n"
+
+# Do not timeout I/O operations on EBS volumes.
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", ATTR{queue/io_timeout}="4294967295"
+
 # instance store nvme devices
 KERNEL=="nvme[0-9]*n[0-9]*",        ENV{DEVTYPE}=="disk",      ATTRS{model}=="Amazon EC2 NVMe Instance Storage", ATTR{queue/io_timeout}="90000"

--- a/amazon-ec2-utils.spec
+++ b/amazon-ec2-utils.spec
@@ -1,7 +1,7 @@
 Name:      amazon-ec2-utils
 Summary:   A set of tools for running in EC2
 Version:   1.3
-Release:   2%{?dist}
+Release:   3%{?dist}
 License:   MIT
 Group:     System Tools
 
@@ -88,6 +88,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/udev/rules.d/70-ec2-nvme-devices.rules
 
 %changelog
+* Thu Jul 14 2021 Sai Harsha <ssuryad@amazon.com> 1.3.3
+- Disable timeout on EBS volumes
+
 * Thu Oct 29 2020 Frederick Lefebvre <fredlef@amazon.com> 1.3-2
 - Add testing of python syntax to spec file
 


### PR DESCRIPTION
Timeouts on EBS volumes can occur due to various reasons, such as
network outages, and can often be recovered after some time.

Timeouts are handled by Linux by remounting the underlying filesystem as
readonly which leads to a bad customer experience.

While the I/O timeout can be specified for the nvme driver via the
kernel commandline or modprobe.d, udev rules are the preferred way of
setting per device timeouts. This is required as local NVMe volumes must have
a finite timeout.

Before Change:
```
[ec2-user@ip-10-0-1-106 ~]$ sudo nvme list
Node             SN                   Model                                    Namespace Usage                      Format           FW Rev  
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
/dev/nvme0n1     vol0f53eccc69bc1e40e Amazon Elastic Block Store               1           0.00   B /   8.59  GB    512   B +  0 B   1.0     
/dev/nvme1n1     AWSBA029A3CE993A5ED5 Amazon EC2 NVMe Instance Storage         1          75.00  GB /  75.00  GB    512   B +  0 B   0

[ec2-user@ip-10-0-1-106 ~]$ grep ^ /sys/block/nvme*/queue/io_timeout
/sys/block/nvme0n1/queue/io_timeout:4294966296
/sys/block/nvme1n1/queue/io_timeout:90000

[ec2-user@ip-10-0-1-106 ~]$ cat /sys/module/nvme_core/parameters/io_timeout 
4294967295
```

After Change:
```
[ec2-user@ip-10-0-1-106 ~]$ sudo nvme list
Node             SN                   Model                                    Namespace Usage                      Format           FW Rev  
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
/dev/nvme0n1     vol0f53eccc69bc1e40e Amazon Elastic Block Store               1           0.00   B /   8.59  GB    512   B +  0 B   1.0     
/dev/nvme1n1     AWSBA029A3CE993A5ED5 Amazon EC2 NVMe Instance Storage         1          75.00  GB /  75.00  GB    512   B +  0 B   0

[ec2-user@ip-10-0-1-106 ~]$ grep ^ /sys/block/nvme*/queue/io_timeout
/sys/block/nvme0n1/queue/io_timeout:4294967288
/sys/block/nvme1n1/queue/io_timeout:90000

[ec2-user@ip-10-0-1-106 ~]$ cat /sys/module/nvme_core/parameters/io_timeout 
30
```

As you can see, the nvme driver was initialized with the default 30s timeout. The udev rule for the EBS volume has been applied successfully as well as the already present rule for local NVMe storage.
