### PR TITLE
ebsnvme-id: open devices in read-only mode

### DIFF
--- a/ebsnvme-id
+++ b/ebsnvme-id
@@ -113,7 +113,7 @@ class ebs_nvme_device:
                                        alen=id_len,
                                        cdw10=1)
 
-        with open(self.device, "r+") as nvme:
+        with open(self.device, "r") as nvme:
             ioctl(nvme, NVME_IOCTL_ADMIN_CMD, admin_cmd)
 
     def ctrl_identify(self):


### PR DESCRIPTION
*Description of changes:*

Opening block devices in read/write mode triggers a kernel change event, which leads to the child devices (corresponding with the partitions) being deleted and recreated.  Opening the fd in read-only mode still provides access to the NVME ioctl() interface, but avoids the unnecessary change event.

*Issue* #15

Tested on Debian unstable (kernel 5.15, python 3.9.9) and Amazon Linux 2 (kernel 4.14, python 2.7.18):

        admin@ip-10-0-0-75:~/amazon-ec2-utils$ git diff master
        diff --git a/ebsnvme-id b/ebsnvme-id
        index c6a31e2..90979f0 100755
        --- a/ebsnvme-id
        +++ b/ebsnvme-id
        @@ -113,7 +113,7 @@ class ebs_nvme_device:
                                                alen=id_len,
                                                cdw10=1)
         
        -        with open(self.device, "r+") as nvme:
        +        with open(self.device, "r") as nvme:
                     ioctl(nvme, NVME_IOCTL_ADMIN_CMD, admin_cmd)
         
             def ctrl_identify(self):
        admin@ip-10-0-0-75:~/amazon-ec2-utils$ stat --format="%i" /dev/nvme1n1p1
        598
        admin@ip-10-0-0-75:~/amazon-ec2-utils$ sudo python3 ./ebsnvme-id /dev/nvme1n1
        Volume ID: vol-019e7bd5b5b3861a0
        sdf
        admin@ip-10-0-0-75:~/amazon-ec2-utils$ stat --format="%i" /dev/nvme1n1p1
        598

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
