### PR TITLE
Correct manpage for ec2-metadata tags

### DIFF
--- a/doc/ec2-metadata.8
+++ b/doc/ec2-metadata.8
@@ -113,7 +113,7 @@ Names of the security groups the instance is launched in. Only available if supp
 .B \-d/\-\-user-data
 User-supplied data.Only available if supplied at instance launch time.
 .TP
-.B \-t/\-\-tags
+.B \-g/\-\-tags
 Print EC2 resource tags if permitted in EC2 Instance Metadata Options.
 .TP
 .B \-\-quiet


### PR DESCRIPTION
Short option for tags is -g not -t.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
